### PR TITLE
Fix for the bounding boxes

### DIFF
--- a/src/main/java/com/sem/btrouble/controller/Collidable.java
+++ b/src/main/java/com/sem/btrouble/controller/Collidable.java
@@ -42,6 +42,9 @@ public interface Collidable {
      */
     float getY();
 
+    float getWidth();
+    float getHeight();
+
     /**
      * Checks for intersection with another Collidable.
      * @param collidable Check if this collidable intersects with that collidable.

--- a/src/main/java/com/sem/btrouble/controller/CollisionHandler.java
+++ b/src/main/java/com/sem/btrouble/controller/CollisionHandler.java
@@ -1,12 +1,16 @@
 package com.sem.btrouble.controller;
 
+import com.sem.btrouble.model.Drawable;
+import org.newdawn.slick.Color;
+import org.newdawn.slick.Graphics;
+
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * Class to handle collisions.
  */
-public class CollisionHandler {
+public class CollisionHandler implements Drawable {
 
     private Collection<Collidable> collidables;
 
@@ -55,7 +59,7 @@ public class CollisionHandler {
 
     /**
      * Get size of list of collidable objects.
-     * 
+     *
      * @return The number of colliable objects
      */
     public int getSize() {
@@ -70,7 +74,7 @@ public class CollisionHandler {
      */
     public boolean checkCollision(Collidable self) {
         boolean collided = false;
-        // Removes all null references. It's an hashset, so duplicates aren't
+        // Removes all null references. It's an set, so duplicates aren't
         // possible.
         collidables.remove(null);
 
@@ -79,16 +83,17 @@ public class CollisionHandler {
         }
 
         for (Collidable collidee : collidables) {
+//            if (self != collidee && collisionCheckAABB(self, collidee)) {
             if (self != collidee && self.intersectsCollidable(collidee)) {
                 // If there is no corresponding CollisionAction for this collision, skip it.
                 CollisionAction selfAction = self.getCollideActions().get(collidee.getClass());
-//                CollisionAction collideeAction = collidee.getCollideActions().get(self.getClass());
+                CollisionAction collideeAction = collidee.getCollideActions().get(self.getClass());
                 if(selfAction != null) {
                     selfAction.onCollision(collidee);
                 }
-//                if(collideeAction != null) {
-//                    collideeAction.onCollision(self);
-//                }
+                if(collideeAction != null) {
+                    collideeAction.onCollision(self);
+                }
                 collided = true;
             }
         }
@@ -110,7 +115,7 @@ public class CollisionHandler {
      */
     public boolean checkCollision(Collection<? extends Collidable> colliders) {
         boolean collided = false;
-        // Removes all null references. It's an hashset, so duplicates aren't
+        // Removes all null references. It's an set, so duplicates aren't
         // possible.
         collidables.remove(null);
 
@@ -159,5 +164,51 @@ public class CollisionHandler {
             return CollisionSide.BOTTOM;
         }
         return CollisionSide.NONE;
+    }
+
+    /**
+     * Use Axis-Aligned Bounding Box collision detection.
+     * @param c1 collidable to check collision with c2.
+     * @param c2 collidable to check collision with c1.
+     * @return True if they collided.
+     */
+    private boolean collisionCheckAABB(Collidable c1, Collidable c2) {
+        float c1minX = c1.getX();
+        float c1maxX = c1.getX() + c1.getWidth();
+        float c2minX = c2.getX();
+        float c2maxX = c2.getX() + c2.getWidth();
+
+        float c1minY = c1.getY();
+        float c1maxY = c1.getY() + c1.getHeight();
+        float c2minY = c2.getY();
+        float c2maxY = c2.getY() + c2.getHeight();
+
+        return c1maxX > c2minX
+                && c1minX < c2maxX
+                && c1maxY > c2minY
+                && c1minY < c2maxY;
+    }
+
+    /**
+     * Draw the object.
+     *
+     * @param graphics
+     */
+    @Override
+    public void draw(Graphics graphics) {
+
+        for(Collidable collidable : collidables) {
+            graphics.setColor(Color.red);
+            graphics.drawRect(collidable.getX(), collidable.getY(),
+//                    Math.abs(collidable.getCenterX() - collidable.getX()),
+//                    Math.abs(collidable.getCenterY() - collidable.gCenteretY())
+                    collidable.getWidth(), collidable.getHeight()
+            );
+            graphics.setColor(Color.green);
+            graphics.drawRect(collidable.getCenterX() - (collidable.getWidth()/2),
+                    collidable.getCenterY() - (collidable.getWidth()/2),
+                    collidable.getWidth(), collidable.getHeight()
+            );
+        }
     }
 }

--- a/src/main/java/com/sem/btrouble/controller/CollisionHandler.java
+++ b/src/main/java/com/sem/btrouble/controller/CollisionHandler.java
@@ -205,8 +205,8 @@ public class CollisionHandler implements Drawable {
                     collidable.getWidth(), collidable.getHeight()
             );
             graphics.setColor(Color.green);
-            graphics.drawRect(collidable.getCenterX() - (collidable.getWidth()/2),
-                    collidable.getCenterY() - (collidable.getWidth()/2),
+            graphics.drawRect(collidable.getCenterX()+1 - (collidable.getWidth()/2),
+                    collidable.getCenterY()+1 - (collidable.getWidth()/2),
                     collidable.getWidth(), collidable.getHeight()
             );
         }

--- a/src/main/java/com/sem/btrouble/controller/Controller.java
+++ b/src/main/java/com/sem/btrouble/controller/Controller.java
@@ -289,6 +289,9 @@ public class Controller implements EventSubject, LevelSubject {
      */
     @Override
     public void notifyObserver() {
+        for(LevelObserver levelObserver : levelObservers) {
+            levelObserver.update(this, collisionHandler);
+        }
         if(!Model.getCurrentRoom().hasBubbles()) {
             for(LevelObserver levelObserver : levelObservers) {
                 levelObserver.levelWon();

--- a/src/main/java/com/sem/btrouble/model/Bubble.java
+++ b/src/main/java/com/sem/btrouble/model/Bubble.java
@@ -294,7 +294,8 @@ public class Bubble extends Circle implements Drawable, Collidable {
      */
     @Override
     public Map<Class<? extends Collidable>, CollisionAction> getCollideActions() {
-        Map<Class<? extends Collidable>, CollisionAction> collisionActionMap = new HashMap<Class<? extends Collidable>, CollisionAction>();
+        Map<Class<? extends Collidable>, CollisionAction> collisionActionMap =
+                new HashMap<Class<? extends Collidable>, CollisionAction>();
 
         // Method called on Wall collision
         collisionActionMap.put(Wall.class, new CollisionAction() {

--- a/src/main/java/com/sem/btrouble/model/Model.java
+++ b/src/main/java/com/sem/btrouble/model/Model.java
@@ -190,7 +190,8 @@ public class Model {
     	ArrayList<PowerUp> powers = new ArrayList<PowerUp>();
     	for(int i = 0; i < powersshort.size(); i++) {
     		PowerUp listPower = powersshort.get(i);
-    		if(power instanceof LifePowerUp) {
+            powers.add(listPower);
+/*    		if(power instanceof LifePowerUp) {
     			if(listPower instanceof SlowPowerUp || listPower instanceof TimePowerUp) {
     				powers.add(listPower);
     			}
@@ -201,7 +202,7 @@ public class Model {
     		} else if (power instanceof TimePowerUp && (listPower instanceof SlowPowerUp
     		        || listPower instanceof LifePowerUp)) {
     			powers.add(listPower);
-    		}
+    		}*/
     	}
 		powersshort = powers;
     }

--- a/src/main/java/com/sem/btrouble/model/Model.java
+++ b/src/main/java/com/sem/btrouble/model/Model.java
@@ -190,8 +190,8 @@ public class Model {
     	ArrayList<PowerUp> powers = new ArrayList<PowerUp>();
     	for(int i = 0; i < powersshort.size(); i++) {
     		PowerUp listPower = powersshort.get(i);
-            powers.add(listPower);
-/*    		if(power instanceof LifePowerUp) {
+//            powers.add(listPower);
+    		if(power instanceof LifePowerUp) {
     			if(listPower instanceof SlowPowerUp || listPower instanceof TimePowerUp) {
     				powers.add(listPower);
     			}
@@ -202,7 +202,7 @@ public class Model {
     		} else if (power instanceof TimePowerUp && (listPower instanceof SlowPowerUp
     		        || listPower instanceof LifePowerUp)) {
     			powers.add(listPower);
-    		}*/
+    		}
     	}
 		powersshort = powers;
     }

--- a/src/main/java/com/sem/btrouble/model/Player.java
+++ b/src/main/java/com/sem/btrouble/model/Player.java
@@ -363,8 +363,8 @@ public class Player extends Rectangle implements Drawable, Collidable {
      *            - y-coordinate
      */
     public void moveTo(int xpos, int ypos) {
-        this.x = xpos;
-        this.y = ypos;
+        setCenterX(xpos);
+        setCenterY(ypos);
         falling = true;
     }
 
@@ -400,12 +400,15 @@ public class Player extends Rectangle implements Drawable, Collidable {
         collisionActionMap.put(Wall.class, new CollisionAction() {
             @Override
             public void onCollision(Collidable collider) {
+                System.out.println("Collided");
                 switch (CollisionHandler.checkCollisionSideX(Player.this, collider)) {
                     case LEFT:
                         setRightBlock(true);
+                        setCenterX(collider.getCenterX() - (collider.getWidth() + getWidth()) / 2);
                         break;
                     case RIGHT:
                         setLeftBlock(true);
+                        setCenterX(collider.getCenterX() + (collider.getWidth() + getWidth()) / 2);
                         break;
                     default:
                         break;
@@ -418,7 +421,7 @@ public class Player extends Rectangle implements Drawable, Collidable {
             @Override
             public void onCollision(Collidable collider) {
                 setFalling(false);
-                setY(collider.getY() - getHeight());
+                setCenterY(collider.getCenterY() - (collider.getHeight() + getHeight()) / 2);
             }
         });
 

--- a/src/main/java/com/sem/btrouble/model/Player.java
+++ b/src/main/java/com/sem/btrouble/model/Player.java
@@ -67,8 +67,6 @@ public class Player extends Rectangle implements Drawable, Collidable {
         leftBlocked = false;
         alive = true;
         falling = true;
-
-        this.observers = new ArrayList<PlayerObserver>();
     }
 
     /**
@@ -282,21 +280,22 @@ public class Player extends Rectangle implements Drawable, Collidable {
                 walkSheet = new SpriteSheet("Sprites/player_spritesheet.png", 100, 175);
                 walkAnimation = new Animation(walkSheet, 20);
             }
+            // Render the sprite at an offset.
+            int playerX = (int) (x
+                    - ((walkSheet.getWidth() / walkSheet.getHorizontalCount()) - getWidth()) / 2);
+            if (!idle) {
+                walkAnimation.getCurrentFrame().getFlippedCopy(facingLeft, false).draw(playerX, y - 15);
+            } else {
+                playerIdle.getFlippedCopy(facingLeft, false).draw(playerX, y - 15);
+            }
+            for (int i = 0; i < ropes.size(); i++) {
+                ropes.get(i).draw(graphics);
+            }
         } catch (SlickException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-        // Render the sprite at an offset.
-        int playerX = (int) (x
-                - ((walkSheet.getWidth() / walkSheet.getHorizontalCount()) - getWidth()) / 2);
-        if (!idle) {
-            walkAnimation.getCurrentFrame().getFlippedCopy(facingLeft, false).draw(playerX, y - 15);
-        } else {
-            playerIdle.getFlippedCopy(facingLeft, false).draw(playerX, y - 15);
-        }
-        for (int i = 0; i < ropes.size(); i++) {
-            ropes.get(i).draw(graphics);
-        }
+
     }
 
     /**
@@ -325,7 +324,8 @@ public class Player extends Rectangle implements Drawable, Collidable {
             idle = false;
             facingLeft = true;
             walkAnimation.update(delta);
-            x -= delta * 0.15f * PLAYER_SPEED;
+//            x -= delta * 0.15f * PLAYER_SPEED;
+            setCenterX(getCenterX() - delta * 0.15f * PLAYER_SPEED);
         }
     }
 
@@ -342,7 +342,8 @@ public class Player extends Rectangle implements Drawable, Collidable {
             idle = false;
             facingLeft = false;
             walkAnimation.update(delta);
-            x += delta * 0.15f * PLAYER_SPEED;
+//            x += delta * 0.15f * PLAYER_SPEED;
+            setCenterX(getCenterX() + delta * 0.15f * PLAYER_SPEED);
         }
     }
 
@@ -371,7 +372,8 @@ public class Player extends Rectangle implements Drawable, Collidable {
      * Slowly fall down vertically.
      */
     public void fall() {
-        y += vy;
+        setCenterY(getCenterY() + vy);
+//        y += vy;
         vy += ay;
     }
 

--- a/src/main/java/com/sem/btrouble/observering/LevelObserver.java
+++ b/src/main/java/com/sem/btrouble/observering/LevelObserver.java
@@ -5,11 +5,12 @@ package com.sem.btrouble.observering;
  */
 public interface LevelObserver {
 
-    /**
+   /**
      * This method is called when the observer is notified about a update.
-     * @param drawables the objects that should be drawn.
+     * @param subject The observable subject.
+     * @param arg Arguments that can be passed.
      */
-    //void update(List<Drawable> drawables);
+    void update(LevelSubject subject, Object arg);
 
     /**
      * This method is called when a level is won.

--- a/src/main/java/com/sem/btrouble/view/GameView.java
+++ b/src/main/java/com/sem/btrouble/view/GameView.java
@@ -2,6 +2,7 @@ package com.sem.btrouble.view;
 
 import com.sem.btrouble.SlickApp;
 import com.sem.btrouble.controller.Controller;
+import com.sem.btrouble.model.Drawable;
 import com.sem.btrouble.model.Timers;
 import com.sem.btrouble.model.Wallet;
 import com.sem.btrouble.observering.LevelObserver;
@@ -20,6 +21,8 @@ import org.newdawn.slick.state.transition.FadeOutTransition;
 import org.newdawn.slick.util.ResourceLoader;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by rubenwiersma on 22-09-15.
@@ -32,6 +35,8 @@ public class GameView extends BasicGameState implements LevelObserver {
     private Audio wavEffect;
     private static Wallet wallet;
     private StateBasedGame sbg;
+    // Used for drawing collisionhandler. For testing purposes, can be removed.
+    private List<Drawable> drawables = new ArrayList<Drawable>();
 
     /**
      * Initialize method of the slick2d library.
@@ -107,6 +112,11 @@ public class GameView extends BasicGameState implements LevelObserver {
     public void render(GameContainer gc, StateBasedGame sbg, Graphics graphics)
             throws SlickException {
         view.draw(graphics);
+        // Used for drawing collisionhandler. For testing purposes, can be removed.
+        for(Drawable d : drawables) {
+            d.draw(graphics);
+        }
+        drawables.clear();
     }
 
     /**
@@ -149,7 +159,11 @@ public class GameView extends BasicGameState implements LevelObserver {
      */
     @Override
     public void update(LevelSubject subject, Object arg) {
-
+        // Used for drawing collisionhandler. For testing purposes, can be removed.
+        if(arg instanceof Drawable) {
+            Drawable drawable = (Drawable) arg;
+            drawables.add(drawable);
+        }
     }
 
     /**

--- a/src/main/java/com/sem/btrouble/view/GameView.java
+++ b/src/main/java/com/sem/btrouble/view/GameView.java
@@ -5,6 +5,7 @@ import com.sem.btrouble.controller.Controller;
 import com.sem.btrouble.model.Timers;
 import com.sem.btrouble.model.Wallet;
 import com.sem.btrouble.observering.LevelObserver;
+import com.sem.btrouble.observering.LevelSubject;
 import com.sem.btrouble.tools.SoundObserver;
 import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.Graphics;
@@ -138,6 +139,17 @@ public class GameView extends BasicGameState implements LevelObserver {
      */
     public Audio getWavEffect() {
         return wavEffect;
+    }
+
+    /**
+     * This method is called when the observer is notified about a update.
+     *
+     * @param subject
+     * @param arg
+     */
+    @Override
+    public void update(LevelSubject subject, Object arg) {
+
     }
 
     /**

--- a/src/main/java/com/sem/btrouble/view/View.java
+++ b/src/main/java/com/sem/btrouble/view/View.java
@@ -69,7 +69,10 @@ public class View {
         drawPowers(graphics);
 //        drawBubbles(graphics);
         drawTimer(graphics);
-        drawBorders(graphics);
+//        drawBorders(graphics);
+        // Draw borders and bubbles.
+        // Can be separate method(or not)?
+        Model.getCurrentRoom().draw(graphics);
 
         drawLives();
         drawScore(graphics);

--- a/src/test/java/com/sem/btrouble/PlayerTest.java
+++ b/src/test/java/com/sem/btrouble/PlayerTest.java
@@ -1,17 +1,16 @@
 package com.sem.btrouble;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-
+import com.sem.btrouble.model.Player;
+import com.sem.btrouble.model.Rope;
 import org.junit.Before;
 import org.junit.Test;
 import org.newdawn.slick.SlickException;
 
-import com.sem.btrouble.model.Player;
-import com.sem.btrouble.model.Rope;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Class which tests the Player class.
@@ -221,7 +220,7 @@ public class PlayerTest {
     @Test
     public void moveToXTest() {
         player.moveTo(5, 5);
-        assertEquals(5, player.getX(), 0);
+        assertEquals(5, player.getCenterX(), 0);
     }
 
     /**
@@ -230,7 +229,7 @@ public class PlayerTest {
     @Test
     public void moveToYTest() {
         player.moveTo(5, 5);
-        assertEquals(5, player.getY(), 0);
+        assertEquals(5, player.getCenterY(), 0);
     }
 
     /**


### PR DESCRIPTION
This fixes the issue where moving the player doesn't change the bounding boxes correctly. 
Moving is changed to use setCenter. 

A draw method is added to the collisionHandler for easy debugging. An axis-aligned bounding box collision check method is also added as a possible replacement for the intersect method of shapes. However, the intersect method is probably better. 
