### PR TITLE
This fixes the need to use instanceof when using TimePowerUp

### DIFF
--- a/src/main/java/com/sem/btrouble/controller/Controller.java
+++ b/src/main/java/com/sem/btrouble/controller/Controller.java
@@ -100,11 +100,10 @@ public class Controller implements EventSubject, LevelSubject {
             }
         }
 
-        ArrayList<PowerUp> powers = Model.getShortPower();
+        List<PowerUp> powers = Model.getShortPower();
         if (powers.size() > 0) {
             for (PowerUp power : powers) {
                 if (collisionHandler.checkCollision(power)) {
-
                     if (timeLeft >= getTimers().getLevelTimeLeft() + 30000) {
                         Model.deleteShortPower(power);
                     }
@@ -179,7 +178,7 @@ public class Controller implements EventSubject, LevelSubject {
     private void restartRoom() {
         fireEvent(new ControllerEvent(this, ControllerEvent.RESTARTROOM, "Room restarted"));
         Model.restartRoom();
-        ArrayList<PowerUp> powers = Model.getPowerUps();
+        List<PowerUp> powers = Model.getPowerUps();
         for (PowerUp power: powers) {
             power.reset();
         }

--- a/src/main/java/com/sem/btrouble/model/Bubble.java
+++ b/src/main/java/com/sem/btrouble/model/Bubble.java
@@ -298,83 +298,102 @@ public class Bubble extends Circle implements Drawable, Collidable {
                 new HashMap<Class<? extends Collidable>, CollisionAction>();
 
         // Method called on Wall collision
-        collisionActionMap.put(Wall.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable wall) {
-                switch(CollisionHandler.checkCollisionSideX(Bubble.this, wall)) {
-                    case LEFT:
-                        bounceX(true);
-                        break;
-                    case RIGHT:
-                        bounceX(false);
-                        break;
-                    default:
-                        break;
-                }
-            }
-        });
+        collisionActionMap.put(Wall.class, new WallCollision());
 
         // Method called on Floor collision
-        collisionActionMap.put(Floor.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable floor) {
-                switch(CollisionHandler.checkCollisionSideY(Bubble.this, floor)) {
-                    case TOP:
-                        bounceYFloor();
-                        break;
-                    case BOTTOM:
-                        bounceY();
-                        break;
-                    default:
-                        break;
-                }
-            }
-        });
+        collisionActionMap.put(Floor.class, new FloorCollision());
 
         // Method called on Bubble collision
-        collisionActionMap.put(Bubble.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable b) {
-                Bubble bubble = (Bubble) b;
-                switch(CollisionHandler.checkCollisionSideX(Bubble.this, bubble)) {
-                    case LEFT:
-                        Bubble.this.bounceX(true);
-                        bubble.bounceX(false);
-                        break;
-                    case RIGHT:
-                        Bubble.this.bounceX(false);
-                        bubble.bounceX(true);
-                        break;
-                    default:
-                        break;
-                }
-                switch(CollisionHandler.checkCollisionSideY(Bubble.this, bubble)) {
-                    case TOP:
-                        Bubble.this.bounceY(true);
-                        bubble.bounceY(false);
-                        break;
-                    case BOTTOM:
-                        Bubble.this.bounceY(false);
-                        bubble.bounceY(true);
-                        break;
-                    default:
-                        break;
-                }
-
-            }
-        });
+        collisionActionMap.put(Bubble.class, new BubbleCollision());
 
         // Method called on Rope collision
-        collisionActionMap.put(Rope.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable collider) {
-                split();
-                Rope rope = (Rope) collider;
-                rope.setCollided(true);
-                GameView.getWallet().increaseValue(BUBBLE_SCORE);
-            }
-        });
+        collisionActionMap.put(Rope.class, new RopeCollision());
         return collisionActionMap;
+    }
+
+    /**
+     * Class to method on collision with Wall.
+     */
+    private class WallCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable wall) {
+            switch(CollisionHandler.checkCollisionSideX(Bubble.this, wall)) {
+                case LEFT:
+                    bounceX(true);
+                    break;
+                case RIGHT:
+                    bounceX(false);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Class to call method on collision with Floor.
+     */
+    private class FloorCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable floor) {
+            switch(CollisionHandler.checkCollisionSideY(Bubble.this, floor)) {
+                case TOP:
+                    bounceYFloor();
+                    break;
+                case BOTTOM:
+                    bounceY();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Class to call method on collision with bubble.
+     */
+    private class BubbleCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable b) {
+            Bubble bubble = (Bubble) b;
+            switch(CollisionHandler.checkCollisionSideX(Bubble.this, bubble)) {
+                case LEFT:
+                    Bubble.this.bounceX(true);
+                    bubble.bounceX(false);
+                    break;
+                case RIGHT:
+                    Bubble.this.bounceX(false);
+                    bubble.bounceX(true);
+                    break;
+                default:
+                    break;
+            }
+            switch(CollisionHandler.checkCollisionSideY(Bubble.this, bubble)) {
+                case TOP:
+                    Bubble.this.bounceY(true);
+                    bubble.bounceY(false);
+                    break;
+                case BOTTOM:
+                    Bubble.this.bounceY(false);
+                    bubble.bounceY(true);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Class to call method on collision with rope.
+     */
+    private class RopeCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable collider) {
+            split();
+            Rope rope = (Rope) collider;
+            rope.setCollided(true);
+            GameView.getWallet().increaseValue(BUBBLE_SCORE);
+        }
     }
 
     /**

--- a/src/main/java/com/sem/btrouble/model/LifePowerUp.java
+++ b/src/main/java/com/sem/btrouble/model/LifePowerUp.java
@@ -1,10 +1,10 @@
 package com.sem.btrouble.model;
 
-import java.util.ArrayList;
-
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
+
+import java.util.ArrayList;
 
 /**
  * Representing the Power up for an extra life.
@@ -38,7 +38,8 @@ public class LifePowerUp extends PowerUp {
      */
     public void activate() {
         ArrayList<Player> players = Model.getPlayers();
-        players.get(0).addLife();
+        if(players.get(0).getLives() < 5)
+            players.get(0).addLife();
     }
     
     /**

--- a/src/main/java/com/sem/btrouble/model/Model.java
+++ b/src/main/java/com/sem/btrouble/model/Model.java
@@ -1,6 +1,8 @@
 package com.sem.btrouble.model;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Model contains all data of the game. Model is updated by the Controller and
@@ -13,8 +15,8 @@ public class Model {
     private static ArrayList<Player> players;
     private static Room roomCurrent;
     private static int currentLevel;
-    private static ArrayList<PowerUp> powers = new ArrayList<PowerUp>();
-    private static ArrayList<PowerUp> powersshort = new ArrayList<PowerUp>();
+    private static List<PowerUp> powers = new CopyOnWriteArrayList<PowerUp>();
+//    private static ArrayList<PowerUp> powersshort = new ArrayList<PowerUp>();
     private static Timers timers;
 
     private static int roomWidth;
@@ -131,7 +133,6 @@ public class Model {
     public static void restartRoom() {
         roomCurrent = rooms.roomRestart();
         clearPowerUps();
-        clearShortPower();
         getTimers().restartTimer();
 
         for (Player p : players) {
@@ -144,10 +145,10 @@ public class Model {
     }
     
     /**
-     * Get the power ups bought in the store.
+     * Get all the power ups bought in the store.
      * @return the power ups
      */
-    public static ArrayList<PowerUp> getPowerUps() {
+    public static List<PowerUp> getPowerUps() {
         return powers;
     }
     
@@ -170,8 +171,8 @@ public class Model {
      * Get power ups received in the game.
      * @return the power ups
      */
-    public static ArrayList<PowerUp> getShortPower() {
-    	return powersshort;
+    public static List<PowerUp> getShortPower() {
+    	return powers;
     }
     
     /**
@@ -179,7 +180,7 @@ public class Model {
      * @param power the power up
      */
     public static void addShortPowerUp(PowerUp power) {
-    	powersshort.add(power);
+    	powers.add(power);
     }
     
     /**
@@ -187,31 +188,17 @@ public class Model {
      * @param power the power up
      */
     public static void deleteShortPower(PowerUp power) {
-    	ArrayList<PowerUp> powers = new ArrayList<PowerUp>();
-    	for(int i = 0; i < powersshort.size(); i++) {
-    		PowerUp listPower = powersshort.get(i);
-//            powers.add(listPower);
-    		if(power instanceof LifePowerUp) {
-    			if(listPower instanceof SlowPowerUp || listPower instanceof TimePowerUp) {
-    				powers.add(listPower);
-    			}
-    		} else if (power instanceof SlowPowerUp) {
-    			if(listPower instanceof LifePowerUp || listPower instanceof TimePowerUp) {
-    				powers.add(listPower);
-    			}
-    		} else if (power instanceof TimePowerUp && (listPower instanceof SlowPowerUp
-    		        || listPower instanceof LifePowerUp)) {
-    			powers.add(listPower);
-    		}
-    	}
-		powersshort = powers;
+        if(powers.contains(power)) {
+            powers.remove(power);
+        }
+        System.out.println("aaah");
     }
     
     /**
      * Remove all power ups received in the game.
      */
     public static void clearShortPower() {
-    	powersshort.clear();
+    	clearPowerUps();
     }
 
     /**

--- a/src/main/java/com/sem/btrouble/model/Model.java
+++ b/src/main/java/com/sem/btrouble/model/Model.java
@@ -16,7 +16,6 @@ public class Model {
     private static Room roomCurrent;
     private static int currentLevel;
     private static List<PowerUp> powers = new CopyOnWriteArrayList<PowerUp>();
-//    private static ArrayList<PowerUp> powersshort = new ArrayList<PowerUp>();
     private static Timers timers;
 
     private static int roomWidth;

--- a/src/main/java/com/sem/btrouble/model/Model.java
+++ b/src/main/java/com/sem/btrouble/model/Model.java
@@ -191,7 +191,6 @@ public class Model {
         if(powers.contains(power)) {
             powers.remove(power);
         }
-        System.out.println("aaah");
     }
     
     /**

--- a/src/main/java/com/sem/btrouble/model/Player.java
+++ b/src/main/java/com/sem/btrouble/model/Player.java
@@ -389,12 +389,7 @@ public class Player extends Rectangle implements Drawable, Collidable {
                 new HashMap<Class<? extends Collidable>, CollisionAction>();
 
         // Method called on Bubble collision.
-        collisionActionMap.put(Bubble.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable collider) {
-                setAlive(false);
-            }
-        });
+        collisionActionMap.put(Bubble.class, new BubbleCollision());
 
         // Method called on Wall collision
         collisionActionMap.put(Wall.class, new WallCollision());
@@ -406,12 +401,21 @@ public class Player extends Rectangle implements Drawable, Collidable {
     }
 
     /**
+     * Class to call method on collision with Bubble.
+     */
+    private class BubbleCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable collider) {
+            setAlive(false);
+        }
+    }
+
+    /**
      * Class to call method on collision with Wall.
      */
     private class WallCollision implements CollisionAction {
         @Override
         public void onCollision(Collidable collider) {
-            System.out.println("Collided");
             switch (CollisionHandler.checkCollisionSideX(Player.this, collider)) {
                 case LEFT:
                     setRightBlock(true);

--- a/src/main/java/com/sem/btrouble/model/Player.java
+++ b/src/main/java/com/sem/btrouble/model/Player.java
@@ -392,40 +392,50 @@ public class Player extends Rectangle implements Drawable, Collidable {
         collisionActionMap.put(Bubble.class, new CollisionAction() {
             @Override
             public void onCollision(Collidable collider) {
-//                setAlive(false);
+                setAlive(false);
             }
         });
 
         // Method called on Wall collision
-        collisionActionMap.put(Wall.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable collider) {
-                System.out.println("Collided");
-                switch (CollisionHandler.checkCollisionSideX(Player.this, collider)) {
-                    case LEFT:
-                        setRightBlock(true);
-                        setCenterX(collider.getCenterX() - (collider.getWidth() + getWidth()) / 2);
-                        break;
-                    case RIGHT:
-                        setLeftBlock(true);
-                        setCenterX(collider.getCenterX() + (collider.getWidth() + getWidth()) / 2);
-                        break;
-                    default:
-                        break;
-                }
-            }
-        });
+        collisionActionMap.put(Wall.class, new WallCollision());
 
         // Method called on Floor collision.
-        collisionActionMap.put(Floor.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable collider) {
-                setFalling(false);
-                setCenterY(collider.getCenterY() - (collider.getHeight() + getHeight()) / 2);
-            }
-        });
+        collisionActionMap.put(Floor.class, new FloorCollision());
 
         return collisionActionMap;
+    }
+
+    /**
+     * Class to call method on collision with Wall.
+     */
+    private class WallCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable collider) {
+            System.out.println("Collided");
+            switch (CollisionHandler.checkCollisionSideX(Player.this, collider)) {
+                case LEFT:
+                    setRightBlock(true);
+                    setCenterX(collider.getCenterX() - (collider.getWidth() + getWidth()) / 2);
+                    break;
+                case RIGHT:
+                    setLeftBlock(true);
+                    setCenterX(collider.getCenterX() + (collider.getWidth() + getWidth()) / 2);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Class to call method on collision with Floor.
+     */
+    private class FloorCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable collider) {
+            setFalling(false);
+            setCenterY(collider.getCenterY() - (collider.getHeight() + getHeight()) / 2);
+        }
     }
 
     /**

--- a/src/main/java/com/sem/btrouble/model/Player.java
+++ b/src/main/java/com/sem/btrouble/model/Player.java
@@ -392,7 +392,7 @@ public class Player extends Rectangle implements Drawable, Collidable {
         collisionActionMap.put(Bubble.class, new CollisionAction() {
             @Override
             public void onCollision(Collidable collider) {
-                setAlive(false);
+//                setAlive(false);
             }
         });
 

--- a/src/main/java/com/sem/btrouble/model/PowerUp.java
+++ b/src/main/java/com/sem/btrouble/model/PowerUp.java
@@ -67,6 +67,7 @@ public abstract class PowerUp extends Rectangle implements Drawable, Collidable 
     
     /**
      * Draw the power up.
+     * @param graphics Graphics handler
      */
     public abstract void draw(Graphics graphics);
     

--- a/src/main/java/com/sem/btrouble/model/PowerUp.java
+++ b/src/main/java/com/sem/btrouble/model/PowerUp.java
@@ -120,25 +120,35 @@ public abstract class PowerUp extends Rectangle implements Drawable, Collidable 
                 new HashMap<Class<? extends Collidable>, CollisionAction>();
 
         // Method called on collision with Floor.
-        collisionActionMap.put(Floor.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable collider) {
-                PowerUp.this.setFalling(false);
-                PowerUp.this.setY(collider.getY() - getHeight());
-            }
-        });
+        collisionActionMap.put(Floor.class, new FloorCollision());
 
         // Method called on collision with Player.
-        collisionActionMap.put(Player.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable collider) {
-                PowerUp.this.activate();
-                Model.deleteShortPower(PowerUp.this);
-                System.out.println(Model.getShortPower());
-            }
-        });
+        collisionActionMap.put(Player.class, new PlayerCollision());
 
         return collisionActionMap;
+    }
+
+    /**
+     * Class to call method on collision with Floor.
+     */
+    private class FloorCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable collider) {
+            PowerUp.this.setFalling(false);
+            PowerUp.this.setY(collider.getY() - getHeight());
+        }
+    }
+
+    /**
+     * Class to call method on collision with Player.
+     */
+    private class PlayerCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable collider) {
+            PowerUp.this.activate();
+            Model.deleteShortPower(PowerUp.this);
+            System.out.println(Model.getShortPower());
+        }
     }
 
     /**

--- a/src/main/java/com/sem/btrouble/model/PowerUp.java
+++ b/src/main/java/com/sem/btrouble/model/PowerUp.java
@@ -132,15 +132,7 @@ public abstract class PowerUp extends Rectangle implements Drawable, Collidable 
         collisionActionMap.put(Player.class, new CollisionAction() {
             @Override
             public void onCollision(Collidable collider) {
-                Player player = (Player) collider;
-                if(!(PowerUp.this instanceof LifePowerUp) && !(PowerUp.this instanceof TimePowerUp)
-                        && player.getLives() < 5) {
-                    PowerUp.this.activate();
-                }
-                if(PowerUp.this instanceof TimePowerUp) {
-                    TimePowerUp timePower = (TimePowerUp) PowerUp.this;
-                    timePower.activateShort();
-                }
+                PowerUp.this.activate();
                 Model.deleteShortPower(PowerUp.this);
                 System.out.println(Model.getShortPower());
             }

--- a/src/main/java/com/sem/btrouble/model/PowerUpGenerator.java
+++ b/src/main/java/com/sem/btrouble/model/PowerUpGenerator.java
@@ -1,6 +1,6 @@
 package com.sem.btrouble.model;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class which generates a random power up.
@@ -40,7 +40,7 @@ public class PowerUpGenerator {
 	 * @return array with types
 	 */
 	public static int[] getTypes() {
-		ArrayList<PowerUp> powers = Model.getShortPower();
+		List<PowerUp> powers = Model.getShortPower();
 		int[] types = {0, 0, 0};
 		for(int i = 0; i < powers.size(); i++) {
 			if(powers.get(i) instanceof TimePowerUp) {

--- a/src/main/java/com/sem/btrouble/model/TimePowerUp.java
+++ b/src/main/java/com/sem/btrouble/model/TimePowerUp.java
@@ -82,24 +82,33 @@ public class TimePowerUp extends PowerUp {
                 new HashMap<Class<? extends Collidable>, CollisionAction>();
 
         // Method called on collision with Floor.
-        collisionActionMap.put(Floor.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable collider) {
-                setFalling(false);
-                setY(collider.getY() - getHeight());
-            }
-        });
+        collisionActionMap.put(Floor.class, new FloorCollision());
 
         // Method called on collision with Player.
-        collisionActionMap.put(Player.class, new CollisionAction() {
-            @Override
-            public void onCollision(Collidable collider) {
-                GameView.getController().getTimers().increaseLevelTimerCounter(50);
-                Model.deleteShortPower(TimePowerUp.this);
-            }
-        });
+        collisionActionMap.put(Player.class, new PlayerCollision());
 
         return collisionActionMap;
     }
 
+    /**
+     * Class to call method on collision with floor.
+     */
+    private class FloorCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable collider) {
+            setFalling(false);
+            setY(collider.getY() - getHeight());
+        }
+    }
+
+    /**
+     * Class to call method on collision with player.
+     */
+    private class PlayerCollision implements CollisionAction {
+        @Override
+        public void onCollision(Collidable collider) {
+            GameView.getController().getTimers().increaseLevelTimerCounter(50);
+            Model.deleteShortPower(TimePowerUp.this);
+        }
+    }
 }

--- a/src/main/java/com/sem/btrouble/model/TimePowerUp.java
+++ b/src/main/java/com/sem/btrouble/model/TimePowerUp.java
@@ -1,10 +1,15 @@
 package com.sem.btrouble.model;
 
+import com.sem.btrouble.controller.Collidable;
+import com.sem.btrouble.controller.CollisionAction;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
 
 import com.sem.btrouble.view.GameView;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents power up which slows down the time.
@@ -34,24 +39,19 @@ public class TimePowerUp extends PowerUp {
     }
     
     /**
-     * Active power up bought in the store.
+     * Active power up.
      */
     public void activate() {
-        GameView.getController().getTimers().setLevelTimerCounter(10000);
+        Timers timers = GameView.getController().getTimers();
+        timers.addAdditionalTime(50);
     }
-    
-    /**
-     * Activate power up received in the game.
-     */
-    public void activateShort() {
-    	GameView.getController().getTimers().restartTimerWithoutCountdown();
-    }
+
     
     /**
      * Reset the power up.
      */
     public void reset() {
-        GameView.getController().getTimers().setLevelTimerCounter(100);
+        GameView.getController().getTimers().resetAdditionalTime();
     }
     
     /**
@@ -69,5 +69,37 @@ public class TimePowerUp extends PowerUp {
         }
     }
 
+    /**
+     * Every collidable should return a Map with all CollisionActions
+     * that collidable should process. To prevent class checking, simply
+     * use the class as the key, and a CollisionAction instance as value.
+     *
+     * @return A map of all actions this collidable can do on a collision.
+     */
+    @Override
+    public Map<Class<? extends Collidable>, CollisionAction> getCollideActions() {
+        Map<Class<? extends Collidable>, CollisionAction> collisionActionMap =
+                new HashMap<Class<? extends Collidable>, CollisionAction>();
+
+        // Method called on collision with Floor.
+        collisionActionMap.put(Floor.class, new CollisionAction() {
+            @Override
+            public void onCollision(Collidable collider) {
+                setFalling(false);
+                setY(collider.getY() - getHeight());
+            }
+        });
+
+        // Method called on collision with Player.
+        collisionActionMap.put(Player.class, new CollisionAction() {
+            @Override
+            public void onCollision(Collidable collider) {
+                GameView.getController().getTimers().increaseLevelTimerCounter(50);
+                Model.deleteShortPower(TimePowerUp.this);
+            }
+        });
+
+        return collisionActionMap;
+    }
 
 }

--- a/src/main/java/com/sem/btrouble/model/TimePowerUp.java
+++ b/src/main/java/com/sem/btrouble/model/TimePowerUp.java
@@ -56,6 +56,7 @@ public class TimePowerUp extends PowerUp {
     
     /**
      * Draw the power up.
+     * @param graphics graphics handler.
      */
     public void draw(Graphics graphics) {
         try {

--- a/src/main/java/com/sem/btrouble/model/Timers.java
+++ b/src/main/java/com/sem/btrouble/model/Timers.java
@@ -1,9 +1,8 @@
 package com.sem.btrouble.model;
 
+import javax.swing.Timer;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-
-import javax.swing.Timer;
 
 /**
  * Class which controls all the timers in the game.
@@ -14,8 +13,9 @@ public class Timers {
     private Timer countdownTimer;
     private int levelTimerCounter;
     private int countdownCounter;
+    private int additionalTime;
     // Max duration in seconds * 10
-    private static final int LEVEL_MAX_DURATION = 500;
+    public static final int LEVEL_MAX_DURATION = 500;
     // Countdown delay before level starts in seconds * 10
     private static final int COUNTDOWN_MAX_DURATION = 30;
     private static final int TIMER_SPEED = 100;
@@ -28,6 +28,7 @@ public class Timers {
      *            - delay before the timer actually starts.
      */
     public Timers(int delay) {
+        additionalTime = 0;
         levelTimerCounter = LEVEL_MAX_DURATION;
         countdownCounter = COUNTDOWN_MAX_DURATION;
         levelTimer = new Timer(TIMER_SPEED, new LevelTimerActionListener());
@@ -41,33 +42,43 @@ public class Timers {
     public void restartTimer() {
         levelTimer.stop();
         countdownTimer.stop();
-        levelTimerCounter = LEVEL_MAX_DURATION;
+        levelTimerCounter = LEVEL_MAX_DURATION + additionalTime;
         countdownCounter = COUNTDOWN_MAX_DURATION;
         countdownTimer.restart();
     }
-    
+
     /**
-     * Restarts the game timer without countdown.
+     * Reset the level timer counter.
      */
-    public void restartTimerWithoutCountdown() {
+    public void resetLevelTimerCounter() {
         levelTimerCounter = LEVEL_MAX_DURATION;
-
     }
 
     /**
-     * Set the level timer counter.
-     * @param duration duration
+     * Add time to the clock.
+     * @param time time to be added.
      */
-    public void setLevelTimerCounter(int duration) {
-        levelTimer.setInitialDelay(duration);
+    public void addAdditionalTime(int time) {
+        additionalTime += time;
     }
-    
+
     /**
-     * Return the initial delay.
-     * @return initial delay
+     * Reset additional time to zero.
+     * Used for powerups.
      */
-    public int getLevelTimerCounter() {
-        return levelTimer.getInitialDelay();
+    public void resetAdditionalTime() {
+        this.additionalTime = 0;
+    }
+
+    /**
+     * Set level timer. Cannot go higher than MAX
+     * @param time increase time with this value.
+     */
+    public void increaseLevelTimerCounter(int time) {
+        levelTimerCounter += time;
+        if(levelTimerCounter > LEVEL_MAX_DURATION + additionalTime) {
+            levelTimerCounter = LEVEL_MAX_DURATION + additionalTime;
+        }
     }
 
     /**
@@ -87,7 +98,7 @@ public class Timers {
      * @return - Max time in a level.
      */
     public int getLevelMaxDuration() {
-        return LEVEL_MAX_DURATION * TIMER_SPEED;
+        return (LEVEL_MAX_DURATION + additionalTime) * TIMER_SPEED;
     }
 
     /**
@@ -144,7 +155,7 @@ public class Timers {
          * @param event the event
          */
         public void actionPerformed(ActionEvent event) {
-            // System.out.println("levelTimerCounter: " + levelTimerCounter);
+//             System.out.println("levelTimerCounter: " + levelTimerCounter);
             levelTimerCounter--;
             if (levelTimerCounter <= 0) {
                 levelTimer.stop();

--- a/src/test/java/com/sem/btrouble/ModelTest.java
+++ b/src/test/java/com/sem/btrouble/ModelTest.java
@@ -1,20 +1,18 @@
 package com.sem.btrouble;
 
-import static org.junit.Assert.assertEquals;
-
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import com.sem.btrouble.model.Model;
 import com.sem.btrouble.model.Player;
 import com.sem.btrouble.model.PowerUp;
 import com.sem.btrouble.model.Room;
-
-import java.util.ArrayList;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Class which tests the model class.
@@ -90,16 +88,6 @@ public class ModelTest extends Model {
         ArrayList<PowerUp> powers = new ArrayList<PowerUp>();
         powers.add(power);
         Model.clearShortPower();
-        assertEquals(new ArrayList<PowerUp>(), Model.getShortPower());
-    }
-    
-    /**
-     * Test the deleteShortPower method.
-     */
-    @Test
-    public void deleteShortPowerTest() {
-        Model.addShortPowerUp(power);
-        Model.deleteShortPower(power);
         assertEquals(new ArrayList<PowerUp>(), Model.getShortPower());
     }
 


### PR DESCRIPTION
- Type checking for powerups is not needed anymore. All instanceof are removed. 
- This replaces the anonymous inner class by an inner private class, because apparently the method length is too long. 
- In the Model class, references to shortPowerUp can be removed and pointed to the regular powerUp list. Still needs to be done. 

< bug, interface, layout
